### PR TITLE
Fix for large subnet definitions and ability to work with Kea 1.5

### DIFF
--- a/kea_exporter/kea.py
+++ b/kea_exporter/kea.py
@@ -511,13 +511,13 @@ class KeaExporter:
             if key.startswith('subnet['):
                 match = self.subnet_pattern.match(key)
                 if match:
-                    subnet_idx = int(match.group('subnet_idx')) - 1
+                    subnet_idx = int(match.group('subnet_idx'))
                     key = match.group('metric')
 
                     if module is Module.DHCP4:
-                        subnet = self.config['Dhcp4']['subnet4'][subnet_idx]
+                        subnet = next(item for item in self.config['Dhcp4']['subnet4'] if item["id"] == subnet_idx)
                     else:
-                        subnet = self.config['Dhcp6']['subnet6'][subnet_idx]
+                        subnet = next(item for item in self.config['Dhcp6']['subnet4'] if item["id"] == subnet_idx)
                     labels['subnet'] = subnet['subnet']
                 else:
                     click.echo('subnet pattern failed for metric: {0}'.format(

--- a/kea_exporter/kea.py
+++ b/kea_exporter/kea.py
@@ -467,6 +467,7 @@ class KeaExporter:
         ]
 
     def update(self):
+        BUFF_SIZE = 1024
         reload_config = False
         for event in self.inotify.event_gen():
             if not event:
@@ -485,7 +486,13 @@ class KeaExporter:
             with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
                 sock.connect(sock_path)
                 sock.send(KeaExporter.msg_statistics_all)
-                response = sock.recv(8192).decode()
+                response = ''
+                while True:
+                    part = sock.recv(BUFF_SIZE).decode()
+                    response += part
+                    if len(part) <  BUFF_SIZE:
+                        break
+                
                 self.parse_metrics(json.loads(response), module)
 
     def parse_metrics(self, response, module):


### PR DESCRIPTION
Hi,
I have never used Kea 1.3, but I guess some stuff changed between 1.3 and 1.5

I tested it with the Kea 1.5 Dhcp4 client and it exports the metrics correctly. (Also works when subnets are not defined in order i.e subnet[5] -> subnet[1] -> subnet[6] ) 