### PR TITLE
Add http support

### DIFF
--- a/kea_exporter/base_exporter.py
+++ b/kea_exporter/base_exporter.py
@@ -531,10 +531,10 @@ class BaseExporter:
                 subnet_metric = subnet_match.group('subnet_metric')
 
                 if dhcp_version is self.DHCPVersion.DHCP4:
-                    if key in self.metric_dhcp4_subnet_ignore:
+                    if pool_metric in self.metric_dhcp4_subnet_ignore or subnet_metric in self.metric_dhcp4_subnet_ignore:
                         continue
                 elif dhcp_version is self.DHCPVersion.DHCP6:
-                    if key in self.metric_dhcp6_subnet_ignore:
+                    if pool_metric in self.metric_dhcp6_subnet_ignore or subnet_metric in self.metric_dhcp6_subnet_ignore:
                         continue
                 else:
                     continue

--- a/kea_exporter/base_exporter.py
+++ b/kea_exporter/base_exporter.py
@@ -566,7 +566,7 @@ class BaseExporter:
                 if pool_index:
                     # Matched for subnet pool metrics
                     pool_index = int(pool_index)
-                    subnet_pools = subnet_data.get("pools", [])
+                    subnet_pools = [pool.get("pool") for pool in subnet_data.get("pools", [])]
 
                     if len(subnet_pools) <= pool_index:
                         if f"{subnet_id}-{pool_index}" not in self.subnet_missing_info_sent.get(dhcp_version, []):

--- a/kea_exporter/base_exporter.py
+++ b/kea_exporter/base_exporter.py
@@ -82,8 +82,8 @@ class BaseExporter:
                 f'{self.prefix_dhcp4}_reservation_conflicts_total',
                 'Reservation conflict count',
                 ['subnet', 'subnet_id']),
-            'reused_leases': Gauge(
-                f'{self.prefix_dhcp4}_reused_leases',
+            'leases_reused_total': Gauge(
+                f'{self.prefix_dhcp4}_leases_reused_total',
                 'Number of times an IPv4 lease had its CLTT increased in memory and its expiration time left unchanged in persistent storage as part of the lease caching feature.',
                 ['subnet', 'subnet_id']),
         }

--- a/kea_exporter/base_exporter.py
+++ b/kea_exporter/base_exporter.py
@@ -207,7 +207,7 @@ class BaseExporter:
             },
 
             'v4-lease-reuses': {
-                'metric' : 'reused_leases',
+                'metric' : 'leases_reused_total',
             },
 
             'assigned-addresses': {

--- a/kea_exporter/base_exporter.py
+++ b/kea_exporter/base_exporter.py
@@ -45,7 +45,7 @@ class BaseExporter:
             'addresses_allocation_fail': Gauge(
                 f'{self.prefix_dhcp4}_allocations_failed_total',
                 'Allocation fail count',
-                ['subnet', 'subnet_id', 'pool', 'context',]),
+                ['subnet', 'subnet_id', 'context',]),
             'addresses_assigned_total': Gauge(
                 f'{self.prefix_dhcp4}_addresses_assigned_total',
                 'Assigned addresses',
@@ -69,7 +69,7 @@ class BaseExporter:
             'reservation_conflicts_total': Gauge(
                 f'{self.prefix_dhcp4}_reservation_conflicts_total',
                 'Reservation conflict count',
-                ['subnet', 'subnet_id', 'pool']),
+                ['subnet', 'subnet_id']),
         }
 
         self.metrics_dhcp4_map = {
@@ -261,7 +261,7 @@ class BaseExporter:
             'addresses_allocation_fail': Gauge(
                 f'{self.prefix_dhcp6}_allocations_failed_total',
                 'Allocation fail count',
-                ['subnet', 'subnet_id', 'pool', 'context',]),
+                ['subnet', 'subnet_id', 'context',]),
             'addresses_declined_total': Gauge(
                 f'{self.prefix_dhcp6}_addresses_declined_total',
                 'Declined addresses',
@@ -277,7 +277,7 @@ class BaseExporter:
             'reservation_conflicts_total': Gauge(
                 f'{self.prefix_dhcp6}_reservation_conflicts_total',
                 'Reservation conflict count',
-                ['subnet', 'subnet_id', 'pool']),
+                ['subnet', 'subnet_id']),
 
             # IA_NA
             'na_assigned_total': Gauge(
@@ -294,11 +294,11 @@ class BaseExporter:
             'pd_assigned_total': Gauge(
                 f'{self.prefix_dhcp6}_pd_assigned_total',
                 'Assigned prefix delegations (IA_PD)',
-                ['subnet', 'subnet_id', 'pool']),
+                ['subnet', 'subnet_id']),
             'pd_total': Gauge(
                 f'{self.prefix_dhcp6}_pd_total',
                 'Size of prefix delegation pool',
-                ['subnet', 'subnet_id', 'pool']
+                ['subnet', 'subnet_id']
             ),
 
         }

--- a/kea_exporter/base_exporter.py
+++ b/kea_exporter/base_exporter.py
@@ -5,7 +5,7 @@ from prometheus_client import Gauge
 
 class BaseExporter:
     subnet_pattern = re.compile(
-        r"subnet\[(?P<subnet_id>[\d]+)\]\.(?P<metric>[\w-]+)")
+        r"^subnet\[(?P<subnet_id>[\d]+)\]\.(pool\[(?P<pool_index>[\d]+)\]\.(?P<pool_metric>[\w-]+)|(?P<subnet_metric>[\w-]+))$")
 
     def __init__(self):
         # prometheus
@@ -41,35 +41,35 @@ class BaseExporter:
                 'Packets received',
                 ['operation']),
 
-            # per Subnet
+            # per Subnet or Subnet pool
             'addresses_allocation_fail': Gauge(
                 f'{self.prefix_dhcp4}_allocations_failed_total',
                 'Allocation fail count',
-                ['subnet', 'subnet_id', 'context',]),
+                ['subnet', 'subnet_id', 'pool', 'context',]),
             'addresses_assigned_total': Gauge(
                 f'{self.prefix_dhcp4}_addresses_assigned_total',
                 'Assigned addresses',
-                ['subnet', 'subnet_id']),
+                ['subnet', 'subnet_id', 'pool']),
             'addresses_declined_total': Gauge(
                 f'{self.prefix_dhcp4}_addresses_declined_total',
                 'Declined counts',
-                ['subnet', 'subnet_id']),
+                ['subnet', 'subnet_id', 'pool']),
             'addresses_declined_reclaimed_total': Gauge(
                 f'{self.prefix_dhcp4}_addresses_declined_reclaimed_total',
                 'Declined addresses that were reclaimed',
-                ['subnet', 'subnet_id']),
+                ['subnet', 'subnet_id', 'pool']),
             'addresses_reclaimed_total': Gauge(
                 f'{self.prefix_dhcp4}_addresses_reclaimed_total',
                 'Expired addresses that were reclaimed',
-                ['subnet', 'subnet_id']),
+                ['subnet', 'subnet_id', 'pool']),
             'addresses_total': Gauge(
                 f'{self.prefix_dhcp4}_addresses_total',
                 'Size of subnet address pool',
-                ['subnet', 'subnet_id']),
+                ['subnet', 'subnet_id', 'pool']),
             'reservation_conflicts_total': Gauge(
                 f'{self.prefix_dhcp4}_reservation_conflicts_total',
                 'Reservation conflict count',
-                ['subnet', 'subnet_id']),
+                ['subnet', 'subnet_id', 'pool']),
         }
 
         self.metrics_dhcp4_map = {
@@ -161,7 +161,7 @@ class BaseExporter:
                 }
             },
 
-            # per Subnet
+            # per Subnet or pool
             'v4-allocation-fail-subnet' :{
                 'metric' : 'addresses_allocation_fail',
                 'labels': {
@@ -257,48 +257,48 @@ class BaseExporter:
                 ['operation']
             ),
 
-            # per Subnet
+            # per Subnet or pool
             'addresses_allocation_fail': Gauge(
                 f'{self.prefix_dhcp6}_allocations_failed_total',
                 'Allocation fail count',
-                ['subnet', 'subnet_id', 'context',]),
+                ['subnet', 'subnet_id', 'pool', 'context',]),
             'addresses_declined_total': Gauge(
                 f'{self.prefix_dhcp6}_addresses_declined_total',
                 'Declined addresses',
-                ['subnet', 'subnet_id']),
+                ['subnet', 'subnet_id', 'pool']),
             'addresses_declined_reclaimed_total': Gauge(
                 f'{self.prefix_dhcp6}_addresses_declined_reclaimed_total',
                 'Declined addresses that were reclaimed',
-                ['subnet', 'subnet_id']),
+                ['subnet', 'subnet_id', 'pool']),
             'addresses_reclaimed_total': Gauge(
                 f'{self.prefix_dhcp6}_addresses_reclaimed_total',
                 'Expired addresses that were reclaimed',
-                ['subnet', 'subnet_id']),
+                ['subnet', 'subnet_id', 'pool']),
             'reservation_conflicts_total': Gauge(
                 f'{self.prefix_dhcp6}_reservation_conflicts_total',
                 'Reservation conflict count',
-                ['subnet', 'subnet_id']),
+                ['subnet', 'subnet_id', 'pool']),
 
             # IA_NA
             'na_assigned_total': Gauge(
                 f'{self.prefix_dhcp6}_na_assigned_total',
                 'Assigned non-temporary addresses (IA_NA)',
-                ['subnet', 'subnet_id']),
+                ['subnet', 'subnet_id', 'pool']),
             'na_total': Gauge(
                 f'{self.prefix_dhcp6}_na_total',
                 'Size of non-temporary address pool',
-                ['subnet', 'subnet_id']
+                ['subnet', 'subnet_id', 'pool']
             ),
 
             # IA_PD
             'pd_assigned_total': Gauge(
                 f'{self.prefix_dhcp6}_pd_assigned_total',
                 'Assigned prefix delegations (IA_PD)',
-                ['subnet', 'subnet_id']),
+                ['subnet', 'subnet_id', 'pool']),
             'pd_total': Gauge(
                 f'{self.prefix_dhcp6}_pd_total',
                 'Size of prefix delegation pool',
-                ['subnet', 'subnet_id']
+                ['subnet', 'subnet_id', 'pool']
             ),
 
         }

--- a/kea_exporter/base_exporter.py
+++ b/kea_exporter/base_exporter.py
@@ -553,7 +553,7 @@ class BaseExporter:
                     if subnet_id not in self.subnet_missing_info_sent.get(dhcp_version, []):
                         self.subnet_missing_info_sent.get(dhcp_version, []).append(subnet_id)
                         click.echo(
-                            f"The subnet with id {subnet_id}, dhcp_version: {dhcp_version.name}, appeared in statistics "
+                            f"The subnet_id: {subnet_id}, dhcp_version: {dhcp_version.name}, appeared in statistics "
                             f"but is not part of the configuration anymore! Ignoring.",
                             file=sys.stderr
                         )
@@ -572,7 +572,7 @@ class BaseExporter:
                         if f"{subnet_id}-{pool_index}" not in self.subnet_missing_info_sent.get(dhcp_version, []):
                             self.subnet_missing_info_sent.get(dhcp_version, []).append(f"{subnet_id}-{pool_index}")
                             click.echo(
-                                f"The subnet with id {subnet_id} and pool_index {pool_index}, dhcp_version: {dhcp_version.name}, appeared in statistics "
+                                f"The subnet_id: {subnet_id}, pool_index: {pool_index}, dhcp_version: {dhcp_version.name}, appeared in statistics "
                                 f"but is not part of the configuration anymore! Ignoring.",
                                 file=sys.stderr
                             )

--- a/kea_exporter/base_exporter.py
+++ b/kea_exporter/base_exporter.py
@@ -1,83 +1,13 @@
-import json
-import os
 import re
-import socket
-import sys
-from enum import Enum
 
-import click
 from prometheus_client import Gauge
 
 
-class DHCPVersion(Enum):
-    DHCP4 = 1
-    DHCP6 = 2
-
-
-class KeaSocket:
-    def __init__(self, sock_path):
-        try:
-            if not os.access(sock_path, os.F_OK):
-                raise FileNotFoundError()
-            if not os.access(sock_path, os.R_OK | os.W_OK):
-                raise PermissionError()
-            self.sock_path = os.path.abspath(sock_path)
-        except FileNotFoundError:
-            click.echo(f'Socket at {sock_path} does not exist. Is Kea running?', file=sys.stderr)
-            sys.exit(1)
-        except PermissionError:
-            click.echo(f'Socket at {sock_path} is not read-/writeable.', file=sys.stderr)
-            sys.exit(1)
-
-        self.version = None
-        self.config = None
-        self.subnets = None
-        self.subnet_missing_info_sent = []
-        self.dhcp_version = None
-
-    def query(self, command):
-        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
-            sock.connect(self.sock_path)
-            sock.send(bytes(json.dumps({'command': command}), 'utf-8'))
-            response = json.loads(sock.makefile().read(-1))
-
-        if response['result'] != 0:
-            raise ValueError
-
-        return response
-
-    def stats(self):
-        # I don't currently know how to detect a changed configuration, so
-        # unfortunately we're reloading more often now as a workaround.
-        self.reload()
-
-        return self.query('statistic-get-all')
-
-    def reload(self):
-        self.config = self.query('config-get')['arguments']
-
-        if 'Dhcp4' in self.config:
-            self.dhcp_version = DHCPVersion.DHCP4
-            subnets = self.config['Dhcp4']['subnet4']
-        elif 'Dhcp6' in self.config:
-            self.dhcp_version = DHCPVersion.DHCP6
-            subnets = self.config['Dhcp6']['subnet6']
-        else:
-            click.echo(f'Socket {self.sock_path} has no supported configuration', file=sys.stderr)
-            sys.exit(1)
-
-        # create subnet map
-        self.subnets = {subnet['id']: subnet for subnet in subnets}
-
-
-class KeaExporter:
+class BaseExporter:
     subnet_pattern = re.compile(
         r"subnet\[(?P<subnet_id>[\d]+)\]\.(?P<metric>[\w-]+)")
 
-    def __init__(self, kea_instances):
-        # kea instances
-        self.kea_instances = kea_instances
-
+    def __init__(self):
         # prometheus
         self.prefix = 'kea'
         self.prefix_dhcp4 = f'{self.prefix}_dhcp4'
@@ -97,6 +27,7 @@ class KeaExporter:
 
         # track unhandled metric keys, to notify only once
         self.unhandled_metrics = set()
+
 
     def setup_dhcp4_metrics(self):
         self.metrics_dhcp4 = {
@@ -565,76 +496,3 @@ class KeaExporter:
             'cumulative-assigned-pds',
             'v6-allocation-fail',
         ]
-
-    def update(self):
-        for kea in self.kea_instances:
-            for key, data in kea.stats()['arguments'].items():
-                if kea.dhcp_version is DHCPVersion.DHCP4:
-                    if key in self.metrics_dhcp4_global_ignore:
-                        continue
-                elif kea.dhcp_version is DHCPVersion.DHCP6:
-                    if key in self.metrics_dhcp6_global_ignore:
-                        continue
-                else:
-                    continue
-
-                value, timestamp = data[0]
-                labels = {}
-
-                # Additional matching is required when we encounter a subnet
-                # metric.
-                if key.startswith('subnet['):
-                    match = self.subnet_pattern.match(key)
-                    if match:
-                        subnet_id = int(match.group('subnet_id'))
-                        key = match.group('metric')
-
-                        if kea.dhcp_version is DHCPVersion.DHCP4:
-                            if key in self.metric_dhcp4_subnet_ignore:
-                                continue
-                        elif kea.dhcp_version is DHCPVersion.DHCP6:
-                            if key in self.metric_dhcp6_subnet_ignore:
-                                continue
-                        else:
-                            continue
-
-                        try:
-                            subnet = kea.subnets[subnet_id]
-                        except KeyError:
-                            if subnet_id not in kea.subnet_missing_info_sent:
-                                kea.subnet_missing_info_sent.append(subnet_id)
-                                click.echo(
-                                    f"The subnet with id {subnet_id} on socket {kea.sock_path} appeared in statistics "
-                                    f"but is not part of the configuration anymore! Ignoring.",
-                                    file=sys.stderr
-                                )
-                            continue
-                        labels['subnet'] = subnet['subnet']
-                        labels['subnet_id'] = subnet_id
-                    else:
-                        click.echo(f'subnet pattern failed for metric: {key}',
-                                   file=sys.stderr)
-
-                if kea.dhcp_version is DHCPVersion.DHCP4:
-                    metrics_map = self.metrics_dhcp4_map
-                    metrics = self.metrics_dhcp4
-                elif kea.dhcp_version is DHCPVersion.DHCP6:
-                    metrics_map = self.metrics_dhcp6_map
-                    metrics = self.metrics_dhcp6
-                else:
-                    continue
-
-                try:
-                    metric_info = metrics_map[key]
-                except KeyError:
-                    if key not in self.unhandled_metrics:
-                        click.echo(f"Unhandled metric '{key}', please open an issue at https://github.com/mweinelt/kea-exporter/issues")
-                        self.unhandled_metrics.add(key)
-                    continue
-                metric = metrics[metric_info['metric']]
-
-                # merge static and dynamic labels
-                labels.update(metric_info.get('labels', {}))
-
-                # export labels and value
-                metric.labels(**labels).set(value)

--- a/kea_exporter/base_exporter.py
+++ b/kea_exporter/base_exporter.py
@@ -82,6 +82,10 @@ class BaseExporter:
                 f'{self.prefix_dhcp4}_reservation_conflicts_total',
                 'Reservation conflict count',
                 ['subnet', 'subnet_id']),
+            'reused_leases': Gauge(
+                f'{self.prefix_dhcp4}_reused_leases',
+                'Number of times an IPv4 lease had its CLTT increased in memory and its expiration time left unchanged in persistent storage as part of the lease caching feature.',
+                ['subnet', 'subnet_id']),
         }
 
         self.metrics_dhcp4_map = {
@@ -201,6 +205,11 @@ class BaseExporter:
                     'context': 'classes'
                 },
             },
+
+            'v4-lease-reuses': {
+                'metric' : 'reused_leases',
+            },
+
             'assigned-addresses': {
                 'metric': 'addresses_assigned_total',
             },
@@ -236,7 +245,7 @@ class BaseExporter:
             'v4-allocation-fail-classes',
             'pkt4-sent',
             'pkt4-received',
-
+            'v4-lease-reuses',
         ]
         # Ignore list for subnet level metrics
         self.metric_dhcp4_subnet_ignore = [

--- a/kea_exporter/cli.py
+++ b/kea_exporter/cli.py
@@ -1,11 +1,9 @@
 import time
-import sys
 import click
+
 from prometheus_client import start_http_server
 
 from . import __PROJECT__, __VERSION__
-
-
 
 @click.command()
 @click.argument("mode", envvar='MODE', type=click.Choice(['socket', 'http'], case_sensitive=True), required=True)
@@ -18,7 +16,7 @@ from . import __PROJECT__, __VERSION__
 def cli(mode, port, address, interval, **kwargs):
     
     if mode == "socket":
-        from .kea_socket_exporter import KeaSocketExporter  as KeaExporter
+        from .kea_socket_exporter import KeaSocketExporter as KeaExporter
     elif mode == "http":
         from .kea_http_exporter import KeaHTTPExporter as KeaExporter
 

--- a/kea_exporter/cli.py
+++ b/kea_exporter/cli.py
@@ -9,11 +9,11 @@ from . import __PROJECT__, __VERSION__
 
 @click.command()
 @click.argument("mode", envvar='MODE', type=click.Choice(['socket', 'http'], case_sensitive=True), required=True)
-@click.option('-a', '--address', default='0.0.0.0', help='Specify the address to bind against.')
-@click.option('-p', '--port', type=int, default=9547, help='Specify the port on which to listen.')
-@click.option('-i', '--interval', type=int, default=7.5, help='Specify the metrics update interval in seconds.')
-@click.option('-t', '--target', type=str, default=7.5, help='Target address and port of Kea server, e.g. http://kea.example.com:8080.')
-@click.argument('sockets', nargs=-1, required=False)
+@click.option('-a', '--address', envvar='ADDRESS', default='0.0.0.0', help='Specify the address to bind against.')
+@click.option('-p', '--port', envvar='PORT', type=int, default=9547, help='Specify the port on which to listen.')
+@click.option('-i', '--interval', envvar='INTERVAL', type=int, default=7.5, help='Specify the metrics update interval in seconds.')
+@click.option('-t', '--target', envvar='TARGET', type=str, default=7.5, help='Target address and port of Kea server, e.g. http://kea.example.com:8080.')
+@click.argument('sockets', envvar='SOCKETS', nargs=-1, required=False)
 @click.version_option(prog_name=__PROJECT__, version=__VERSION__)
 def cli(mode, port, address, interval, **kwargs):
     

--- a/kea_exporter/cli.py
+++ b/kea_exporter/cli.py
@@ -6,11 +6,11 @@ from prometheus_client import start_http_server
 from . import __PROJECT__, __VERSION__
 
 @click.command()
-@click.argument("mode", envvar='MODE', type=click.Choice(['socket', 'http'], case_sensitive=True), required=True)
+@click.option('-m', '--mode', envvar='MODE', default='socket', type=click.Choice(['socket', 'http'], case_sensitive=True))
 @click.option('-a', '--address', envvar='ADDRESS', default='0.0.0.0', help='Specify the address to bind against.')
 @click.option('-p', '--port', envvar='PORT', type=int, default=9547, help='Specify the port on which to listen.')
 @click.option('-i', '--interval', envvar='INTERVAL', type=int, default=7.5, help='Specify the metrics update interval in seconds.')
-@click.option('-t', '--target', envvar='TARGET', type=str, default=7.5, help='Target address and port of Kea server, e.g. http://kea.example.com:8080.')
+@click.option('-t', '--target', envvar='TARGET', type=str, help='Target address and port of Kea server, e.g. http://kea.example.com:8080.')
 @click.argument('sockets', envvar='SOCKETS', nargs=-1, required=False)
 @click.version_option(prog_name=__PROJECT__, version=__VERSION__)
 def cli(mode, port, address, interval, **kwargs):

--- a/kea_exporter/cli.py
+++ b/kea_exporter/cli.py
@@ -1,25 +1,32 @@
 import time
-
+import sys
 import click
 from prometheus_client import start_http_server
 
 from . import __PROJECT__, __VERSION__
-from .kea import KeaExporter, KeaSocket
+
 
 
 @click.command()
-@click.argument('sockets', nargs=-1, required=True)
-@click.option('--address', default='0.0.0.0', help='Specify the address to bind against.')
-@click.option('--port', type=int, default=9547, help='Specify the port on which to listen.')
-@click.option('--interval', type=int, default=7.5, help='Specify the metrics update interval in seconds.')
+@click.argument("mode", envvar='MODE', type=click.Choice(['socket', 'http'], case_sensitive=True), required=True)
+@click.option('-a', '--address', default='0.0.0.0', help='Specify the address to bind against.')
+@click.option('-p', '--port', type=int, default=9547, help='Specify the port on which to listen.')
+@click.option('-i', '--interval', type=int, default=7.5, help='Specify the metrics update interval in seconds.')
+@click.option('-t', '--target', type=str, default=7.5, help='Target address and port of Kea server, e.g. http://kea.example.com:8080.')
+@click.argument('sockets', nargs=-1, required=False)
 @click.version_option(prog_name=__PROJECT__, version=__VERSION__)
-def cli(sockets, address, port, interval):
+def cli(mode, port, address, interval, **kwargs):
+    
+    if mode == "socket":
+        from .kea_socket_exporter import KeaSocketExporter  as KeaExporter
+    elif mode == "http":
+        from .kea_http_exporter import KeaHTTPExporter as KeaExporter
+
+    exporter = KeaExporter(**kwargs)
+    exporter.update()
+    
     start_http_server(port, address)
     click.echo("Listening on http://{0}:{1}".format(address, port))
-
-    sockets = [KeaSocket(socket) for socket in sockets]
-    exporter = KeaExporter(sockets)
-    exporter.update()
 
     while True:
         time.sleep(interval)

--- a/kea_exporter/cli.py
+++ b/kea_exporter/cli.py
@@ -6,7 +6,7 @@ from prometheus_client import start_http_server
 from . import __PROJECT__, __VERSION__
 
 @click.command()
-@click.option('-m', '--mode', envvar='MODE', default='socket', type=click.Choice(['socket', 'http'], case_sensitive=True))
+@click.option('-m', '--mode', envvar='MODE', default='socket', help='Select mode.', type=click.Choice(['socket', 'http'], case_sensitive=True))
 @click.option('-a', '--address', envvar='ADDRESS', default='0.0.0.0', help='Specify the address to bind against.')
 @click.option('-p', '--port', envvar='PORT', type=int, default=9547, help='Specify the port on which to listen.')
 @click.option('-i', '--interval', envvar='INTERVAL', type=int, default=7.5, help='Specify the metrics update interval in seconds.')

--- a/kea_exporter/kea_http_exporter.py
+++ b/kea_exporter/kea_http_exporter.py
@@ -1,0 +1,126 @@
+import sys
+import requests
+
+import click
+
+from .base_exporter import BaseExporter
+
+
+class KeaHTTPExporter(BaseExporter):
+    def __init__(self, target, **kwargs):
+        super().__init__()
+        self._target = target
+
+        self.modules = []
+        self.subnets = {}
+        self.subnets6 = {}
+
+        self.subnet_missing_info_sent = {"dhcp4": [], "dhcp6": []}
+
+        self.load_modules()
+
+        self.load_subnets()
+
+
+    def load_modules(self):
+        r = requests.post(self._target, json = {'command': 'config-get'},
+            headers={'Content-Type': 'application/json'})
+        config= r.json()
+        for module in (config[0]['arguments']['Control-agent']
+            ['control-sockets']):
+            if "dhcp" in module: # Does not support d2 metrics. # Does not handle ctrl sockets that are offline
+                self.modules.append(module)
+
+
+    def load_subnets(self):
+        r = requests.post(self._target, json = {'command': 'config-get',
+            'service': self.modules },
+            headers={'Content-Type': 'application/json'})
+        config = r.json()
+        for module in config:
+            for subnet in (module['arguments'].get('Dhcp4', {}).get('subnet4', {})):
+                self.subnets.update( {subnet['id']: subnet['subnet']} )
+            for subnet in (module['arguments'].get('Dhcp6', {}).get('subnet6', {})):
+                self.subnets6.update( {subnet['id']: subnet['subnet']} )
+
+
+    def update(self):
+        # Reload subnets on update in case of configurational update
+        self.load_subnets()
+        # Note for future testing: pipe curl output to jq for an easier read
+        r = requests.post(self._target, json = {'command':
+            'statistic-get-all', 'arguments': { }, 'service': self.modules },
+                headers={'Content-Type': 'application/json'})
+        self.parse_metrics(r.json())
+
+
+    def parse_metrics(self, response):
+        for index, module in enumerate(self.modules):
+            for key, data in response[index]['arguments'].items():
+                if module == 'dhcp4':
+                    if key in self.metrics_dhcp4_global_ignore:
+                        continue
+                elif module == 'dhcp6':
+                    if key in self.metrics_dhcp6_global_ignore:
+                        continue
+                else:
+                    continue
+
+                value, timestamp = data[0]
+                labels = {}
+                if key.startswith('subnet['):
+                    match = self.subnet_pattern.match(key)
+
+                    if match:
+                        subnet_id = int(match.group('subnet_id'))
+
+                        key = match.group('metric')
+                        if module == 'dhcp4':
+                            subnet = self.subnets.get(subnet_id)
+                        elif module == 'dhcp6':
+                            subnet = self.subnets6.get(subnet_id)
+                        else:
+                            continue
+                    
+                        try:
+                            subnet = self.subnets[subnet_id]
+                        except KeyError:
+                            if subnet_id not in self.subnet_missing_info_sent.get(module, []):
+                                self.subnet_missing_info_sent.get(module, []).append(subnet_id)
+                                click.echo(
+                                    f"The subnet with id {subnet_id} on module {module} appeared in statistics "
+                                    f"but is not part of the configuration anymore! Ignoring.",
+                                    file=sys.stderr
+                                )
+                            continue
+
+                        labels['subnet'] = subnet
+                        labels['subnet_id'] = subnet_id
+                    else:
+                        print('subnet pattern failed for metric: {0}'.format(
+                            key), file=sys.stderr)
+
+                if module == 'dhcp4':
+                    metrics_map = self.metrics_dhcp4_map
+                    metrics = self.metrics_dhcp4
+                elif module == 'dhcp6':
+                    metrics_map = self.metrics_dhcp6_map
+                    metrics = self.metrics_dhcp6
+                else:
+                    continue
+
+                try:
+                    metric_info = metrics_map[key]
+                except KeyError:
+                    if key not in self.unhandled_metrics:
+                        click.echo(f"Unhandled metric '{key}', please open an issue at https://github.com/mweinelt/kea-exporter/issues")
+                        self.unhandled_metrics.add(key)
+                    continue
+
+                metric = metrics[metric_info['metric']]
+
+                # merge static and dynamic labels
+                labels.update(metric_info.get('labels', {}))
+
+                # export labels and value
+                metric.labels(**labels).set(value)

--- a/kea_exporter/kea_http_exporter.py
+++ b/kea_exporter/kea_http_exporter.py
@@ -15,8 +15,6 @@ class KeaHTTPExporter(BaseExporter):
         self.subnets = {}
         self.subnets6 = {}
 
-        self.subnet_missing_info_sent = {"dhcp4": [], "dhcp6": []}
-
         self.load_modules()
 
         self.load_subnets()
@@ -39,9 +37,9 @@ class KeaHTTPExporter(BaseExporter):
         config = r.json()
         for module in config:
             for subnet in (module.get('arguments', {}).get('Dhcp4', {}).get('subnet4', {})):
-                self.subnets.update( {subnet['id']: {"subnet": subnet['subnet'], "pools": [pool["pool"] for pool in subnet['pools']]}} )
+                self.subnets.update( {subnet['id']: subnet} )
             for subnet in (module.get('arguments', {}).get('Dhcp6', {}).get('subnet6', {})):
-                self.subnets6.update( {subnet['id']: {"subnet": subnet['subnet'], "pools": [pool["pool"] for pool in subnet['pools']]}} )
+                self.subnets6.update( {subnet['id']: subnet} )
 
 
     def update(self):
@@ -51,101 +49,18 @@ class KeaHTTPExporter(BaseExporter):
         r = requests.post(self._target, json = {'command':
             'statistic-get-all', 'arguments': { }, 'service': self.modules },
                 headers={'Content-Type': 'application/json'})
-        self.parse_metrics(r.json())
+        response = r.json()
 
-
-    def parse_metrics(self, response):
         for index, module in enumerate(self.modules):
-            for key, data in response[index].get('arguments', {}).items():
-                if module == 'dhcp4':
-                    if key in self.metrics_dhcp4_global_ignore:
-                        continue
-                elif module == 'dhcp6':
-                    if key in self.metrics_dhcp6_global_ignore:
-                        continue
-                else:
-                    continue
+            if module == 'dhcp4':
+                dhcp_version = self.DHCPVersion.DHCP4
+                subnets = self.subnets
+            elif module == 'dhcp4':
+                dhcp_version = self.DHCPVersion.DHCP6
+                subnets = self.subnets6
+            else:
+                continue
 
-                value, _ = data[0]
-                labels = {}
-                subnet_match = self.subnet_pattern.match(key)
-                if subnet_match:
-                    subnet_id = int(subnet_match.group('subnet_id'))
-                    pool_index = subnet_match.group('pool_index')
-                    pool_metric = subnet_match.group('pool_metric')
-                    subnet_metric = subnet_match.group('subnet_metric')
-
-                    
-                    if module == 'dhcp4':
-                        subnet_data = self.subnets.get(subnet_id, {})
-                    elif module == 'dhcp6':
-                        subnet_data = self.subnets6.get(subnet_id, {})
-
-                    if not subnet_data:
-                        if subnet_id not in self.subnet_missing_info_sent.get(module, []):
-                            self.subnet_missing_info_sent.get(module, []).append(subnet_id)
-                            click.echo(
-                                f"The subnet with id {subnet_id} on module {module} appeared in statistics "
-                                f"but is not part of the configuration anymore! Ignoring.",
-                                file=sys.stderr
-                            )
-                        continue
-                    
-                    labels['subnet'] = subnet_data.get("subnet")
-                    labels['subnet_id'] = subnet_id
-
-                    # Check if subnet matches the pool_index
-                    if pool_index:
-                        # Matched for subnet pool metrics
-                        pool_index = int(pool_index)
-                        subnet_pools = subnet_data.get("pools", [])
-
-                        if len(subnet_pools) <= pool_index:
-                            if f"{subnet_id}-{pool_index}" not in self.subnet_missing_info_sent.get(module, []):
-                                self.subnet_missing_info_sent.get(module, []).append(f"{subnet_id}-{pool_index}")
-                                click.echo(
-                                    f"The subnet with id {subnet_id} and pool_index {pool_index} on module {module} appeared in statistics "
-                                    f"but is not part of the configuration anymore! Ignoring.",
-                                    file=sys.stderr
-                                )
-                            continue
-                        key = pool_metric
-                        labels["pool"] = subnet_pools[pool_index]
-                    else:
-                        # Matched for subnet metrics
-                        key = subnet_metric
-                        labels["pool"] = ""
-                        
-                    
-                    
-
-                if module == 'dhcp4':
-                    metrics_map = self.metrics_dhcp4_map
-                    metrics = self.metrics_dhcp4
-                elif module == 'dhcp6':
-                    metrics_map = self.metrics_dhcp6_map
-                    metrics = self.metrics_dhcp6
-                else:
-                    continue
-
-                try:
-                    metric_info = metrics_map[key]
-                except KeyError:
-                    if key not in self.unhandled_metrics:
-                        click.echo(f"Unhandled metric '{key}', please open an issue at https://github.com/mweinelt/kea-exporter/issues")
-                        self.unhandled_metrics.add(key)
-                    continue
-                    
-
-                
-                
-                metric = metrics[metric_info['metric']]
-
-                # merge static and dynamic labels
-                labels.update(metric_info.get('labels', {}))
-
-                # Filter labels that are not configured for the metric
-                labels = {key: val for key, val in labels.items() if key in metric._labelnames}
-
-                # export labels and value
-                metric.labels(**labels).set(value)
+            arguments = response[index].get('arguments', {})
+            
+            self.parse_metrics(dhcp_version, arguments, subnets)

--- a/kea_exporter/kea_http_exporter.py
+++ b/kea_exporter/kea_http_exporter.py
@@ -52,7 +52,7 @@ class KeaHTTPExporter(BaseExporter):
             if module == 'dhcp4':
                 dhcp_version = self.DHCPVersion.DHCP4
                 subnets = self.subnets
-            elif module == 'dhcp4':
+            elif module == 'dhcp6':
                 dhcp_version = self.DHCPVersion.DHCP6
                 subnets = self.subnets6
             else:

--- a/kea_exporter/kea_http_exporter.py
+++ b/kea_exporter/kea_http_exporter.py
@@ -38,9 +38,9 @@ class KeaHTTPExporter(BaseExporter):
             headers={'Content-Type': 'application/json'})
         config = r.json()
         for module in config:
-            for subnet in (module['arguments'].get('Dhcp4', {}).get('subnet4', {})):
+            for subnet in (module.get('arguments', {}).get('Dhcp4', {}).get('subnet4', {})):
                 self.subnets.update( {subnet['id']: subnet['subnet']} )
-            for subnet in (module['arguments'].get('Dhcp6', {}).get('subnet6', {})):
+            for subnet in (module.get('arguments', {}).get('Dhcp6', {}).get('subnet6', {})):
                 self.subnets6.update( {subnet['id']: subnet['subnet']} )
 
 
@@ -56,7 +56,7 @@ class KeaHTTPExporter(BaseExporter):
 
     def parse_metrics(self, response):
         for index, module in enumerate(self.modules):
-            for key, data in response[index]['arguments'].items():
+            for key, data in response[index].get('arguments', {}).items():
                 if module == 'dhcp4':
                     if key in self.metrics_dhcp4_global_ignore:
                         continue

--- a/kea_exporter/kea_http_exporter.py
+++ b/kea_exporter/kea_http_exporter.py
@@ -1,14 +1,11 @@
-import sys
 import requests
 
-import click
-
 from .base_exporter import BaseExporter
-
 
 class KeaHTTPExporter(BaseExporter):
     def __init__(self, target, **kwargs):
         super().__init__()
+
         self._target = target
 
         self.modules = []

--- a/kea_exporter/kea_http_exporter.py
+++ b/kea_exporter/kea_http_exporter.py
@@ -144,5 +144,8 @@ class KeaHTTPExporter(BaseExporter):
                 # merge static and dynamic labels
                 labels.update(metric_info.get('labels', {}))
 
+                # Filter labels that are not configured for the metric
+                labels = {key: val for key, val in labels.items() if key in metric._labelnames}
+
                 # export labels and value
                 metric.labels(**labels).set(value)

--- a/kea_exporter/kea_socket_exporter.py
+++ b/kea_exporter/kea_socket_exporter.py
@@ -169,5 +169,8 @@ class KeaSocketExporter(BaseExporter):
                 # merge static and dynamic labels
                 labels.update(metric_info.get('labels', {}))
 
+                # Filter labels that are not configured for the metric
+                labels = {key: val for key, val in labels.items() if key in metric._labelnames}
+
                 # export labels and value
                 metric.labels(**labels).set(value)

--- a/kea_exporter/kea_socket_exporter.py
+++ b/kea_exporter/kea_socket_exporter.py
@@ -3,15 +3,9 @@ import os
 import socket
 import sys
 
-from enum import Enum
-
 import click
 
 from .base_exporter import BaseExporter
-
-class DHCPVersion(Enum):
-    DHCP4 = 1
-    DHCP6 = 2
 
 class KeaSocket:
     def __init__(self, sock_path):
@@ -56,10 +50,10 @@ class KeaSocket:
         self.config = self.query('config-get')['arguments']
 
         if 'Dhcp4' in self.config:
-            self.dhcp_version = DHCPVersion.DHCP4
+            self.dhcp_version = BaseExporter.DHCPVersion.DHCP4
             subnets = self.config['Dhcp4']['subnet4']
         elif 'Dhcp6' in self.config:
-            self.dhcp_version = DHCPVersion.DHCP6
+            self.dhcp_version = BaseExporter.DHCPVersion.DHCP6
             subnets = self.config['Dhcp6']['subnet6']
         else:
             click.echo(f'Socket {self.sock_path} has no supported configuration', file=sys.stderr)
@@ -77,100 +71,7 @@ class KeaSocketExporter(BaseExporter):
         self.kea_instances = [KeaSocket(socket) for socket in sockets]
 
 
-
     def update(self):
         for kea in self.kea_instances:
-            for key, data in kea.stats()['arguments'].items():
-                if kea.dhcp_version is DHCPVersion.DHCP4:
-                    if key in self.metrics_dhcp4_global_ignore:
-                        continue
-                elif kea.dhcp_version is DHCPVersion.DHCP6:
-                    if key in self.metrics_dhcp6_global_ignore:
-                        continue
-                else:
-                    continue
-
-                value, _ = data[0]
-                labels = {}
-
-                # Additional matching is required when we encounter a subnet
-                # metric.
-                subnet_match = self.subnet_pattern.match(key)
-                if subnet_match:
-                    subnet_id = int(subnet_match.group('subnet_id'))
-                    pool_index = subnet_match.group('pool_index')
-                    pool_metric = subnet_match.group('pool_metric')
-                    subnet_metric = subnet_match.group('subnet_metric')
-
-                    if kea.dhcp_version is DHCPVersion.DHCP4:
-                        if key in self.metric_dhcp4_subnet_ignore:
-                            continue
-                    elif kea.dhcp_version is DHCPVersion.DHCP6:
-                        if key in self.metric_dhcp6_subnet_ignore:
-                            continue
-                    else:
-                        continue
-
-                    try:
-                        subnet_data = kea.subnets[subnet_id]
-                    except KeyError:
-                        if subnet_id not in kea.subnet_missing_info_sent:
-                            kea.subnet_missing_info_sent.append(subnet_id)
-                            click.echo(
-                                f"The subnet with id {subnet_id} on socket {kea.sock_path} appeared in statistics "
-                                f"but is not part of the configuration anymore! Ignoring.",
-                                file=sys.stderr
-                            )
-                        continue
-                    
-                    labels['subnet'] = subnet_data.get('subnet')
-                    labels['subnet_id'] = subnet_id
-
-                    # Check if subnet matches the pool_index
-                    if pool_index:
-                        # Matched for subnet pool metrics
-                        pool_index = int(pool_index)
-                        subnet_pools = subnet_data.get("pools", [])
-                        
-                        if len(subnet_pools) <= pool_index:
-                            if f"{subnet_id}-{pool_index}" not in kea.subnet_missing_info_sent:
-                                kea.subnet_missing_info_sent.append(f"{subnet_id}-{pool_index}")
-                                click.echo(
-                                    f"The subnet with id {subnet_id} and pool_index {pool_index} on socket {kea.sock_path} appeared in statistics "
-                                    f"but is not part of the configuration anymore! Ignoring.",
-                                    file=sys.stderr
-                                )
-                            continue
-                        key = pool_metric
-                        labels["pool"] = subnet_pools[pool_index]
-                    else:
-                        # Matched for subnet metrics
-                        key = subnet_metric
-                        labels["pool"] = ""
-
-                if kea.dhcp_version is DHCPVersion.DHCP4:
-                    metrics_map = self.metrics_dhcp4_map
-                    metrics = self.metrics_dhcp4
-                elif kea.dhcp_version is DHCPVersion.DHCP6:
-                    metrics_map = self.metrics_dhcp6_map
-                    metrics = self.metrics_dhcp6
-                else:
-                    continue
-
-                try:
-                    metric_info = metrics_map[key]
-                except KeyError:
-                    if key not in self.unhandled_metrics:
-                        click.echo(f"Unhandled metric '{key}', please open an issue at https://github.com/mweinelt/kea-exporter/issues")
-                        self.unhandled_metrics.add(key)
-                    continue
-                metric = metrics[metric_info['metric']]
-
-                # merge static and dynamic labels
-                labels.update(metric_info.get('labels', {}))
-
-                # Filter labels that are not configured for the metric
-                labels = {key: val for key, val in labels.items() if key in metric._labelnames}
-
-                # export labels and value
-                metric.labels(**labels).set(value)
+            kea.dhcp_version
+            self.parse_metrics(kea.dhcp_version, kea.stats().get('arguments'), kea.subnets)

--- a/kea_exporter/kea_socket_exporter.py
+++ b/kea_exporter/kea_socket_exporter.py
@@ -73,5 +73,4 @@ class KeaSocketExporter(BaseExporter):
 
     def update(self):
         for kea in self.kea_instances:
-            kea.dhcp_version
             self.parse_metrics(kea.dhcp_version, kea.stats().get('arguments'), kea.subnets)

--- a/kea_exporter/kea_socket_exporter.py
+++ b/kea_exporter/kea_socket_exporter.py
@@ -1,0 +1,152 @@
+import json
+import os
+import socket
+import sys
+
+from enum import Enum
+
+import click
+
+from .base_exporter import BaseExporter
+
+class DHCPVersion(Enum):
+    DHCP4 = 1
+    DHCP6 = 2
+
+class KeaSocket:
+    def __init__(self, sock_path):
+        try:
+            if not os.access(sock_path, os.F_OK):
+                raise FileNotFoundError()
+            if not os.access(sock_path, os.R_OK | os.W_OK):
+                raise PermissionError()
+            self.sock_path = os.path.abspath(sock_path)
+        except FileNotFoundError:
+            click.echo(f'Socket at {sock_path} does not exist. Is Kea running?', file=sys.stderr)
+            sys.exit(1)
+        except PermissionError:
+            click.echo(f'Socket at {sock_path} is not read-/writeable.', file=sys.stderr)
+            sys.exit(1)
+
+        self.version = None
+        self.config = None
+        self.subnets = None
+        self.subnet_missing_info_sent = []
+        self.dhcp_version = None
+
+    def query(self, command):
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.connect(self.sock_path)
+            sock.send(bytes(json.dumps({'command': command}), 'utf-8'))
+            response = json.loads(sock.makefile().read(-1))
+
+        if response['result'] != 0:
+            raise ValueError
+
+        return response
+
+    def stats(self):
+        # I don't currently know how to detect a changed configuration, so
+        # unfortunately we're reloading more often now as a workaround.
+        self.reload()
+
+        return self.query('statistic-get-all')
+
+    def reload(self):
+        self.config = self.query('config-get')['arguments']
+
+        if 'Dhcp4' in self.config:
+            self.dhcp_version = DHCPVersion.DHCP4
+            subnets = self.config['Dhcp4']['subnet4']
+        elif 'Dhcp6' in self.config:
+            self.dhcp_version = DHCPVersion.DHCP6
+            subnets = self.config['Dhcp6']['subnet6']
+        else:
+            click.echo(f'Socket {self.sock_path} has no supported configuration', file=sys.stderr)
+            sys.exit(1)
+
+        # create subnet map
+        self.subnets = {subnet['id']: subnet for subnet in subnets}
+
+
+class KeaSocketExporter(BaseExporter):
+    def __init__(self, sockets, **kwargs):
+        super().__init__()
+        
+        # kea instances
+        self.kea_instances = [KeaSocket(socket) for socket in sockets]
+
+
+
+    def update(self):
+        for kea in self.kea_instances:
+            for key, data in kea.stats()['arguments'].items():
+                if kea.dhcp_version is DHCPVersion.DHCP4:
+                    if key in self.metrics_dhcp4_global_ignore:
+                        continue
+                elif kea.dhcp_version is DHCPVersion.DHCP6:
+                    if key in self.metrics_dhcp6_global_ignore:
+                        continue
+                else:
+                    continue
+
+                value, timestamp = data[0]
+                labels = {}
+
+                # Additional matching is required when we encounter a subnet
+                # metric.
+                if key.startswith('subnet['):
+                    match = self.subnet_pattern.match(key)
+                    if match:
+                        subnet_id = int(match.group('subnet_id'))
+                        key = match.group('metric')
+
+                        if kea.dhcp_version is DHCPVersion.DHCP4:
+                            if key in self.metric_dhcp4_subnet_ignore:
+                                continue
+                        elif kea.dhcp_version is DHCPVersion.DHCP6:
+                            if key in self.metric_dhcp6_subnet_ignore:
+                                continue
+                        else:
+                            continue
+
+                        try:
+                            subnet = kea.subnets[subnet_id]
+                        except KeyError:
+                            if subnet_id not in kea.subnet_missing_info_sent:
+                                kea.subnet_missing_info_sent.append(subnet_id)
+                                click.echo(
+                                    f"The subnet with id {subnet_id} on socket {kea.sock_path} appeared in statistics "
+                                    f"but is not part of the configuration anymore! Ignoring.",
+                                    file=sys.stderr
+                                )
+                            continue
+                        labels['subnet'] = subnet['subnet']
+                        labels['subnet_id'] = subnet_id
+                    else:
+                        click.echo(f'subnet pattern failed for metric: {key}',
+                                   file=sys.stderr)
+
+                if kea.dhcp_version is DHCPVersion.DHCP4:
+                    metrics_map = self.metrics_dhcp4_map
+                    metrics = self.metrics_dhcp4
+                elif kea.dhcp_version is DHCPVersion.DHCP6:
+                    metrics_map = self.metrics_dhcp6_map
+                    metrics = self.metrics_dhcp6
+                else:
+                    continue
+
+                try:
+                    metric_info = metrics_map[key]
+                except KeyError:
+                    if key not in self.unhandled_metrics:
+                        click.echo(f"Unhandled metric '{key}', please open an issue at https://github.com/mweinelt/kea-exporter/issues")
+                        self.unhandled_metrics.add(key)
+                    continue
+                metric = metrics[metric_info['metric']]
+
+                # merge static and dynamic labels
+                labels.update(metric_info.get('labels', {}))
+
+                # export labels and value
+                metric.labels(**labels).set(value)


### PR DESCRIPTION
Renamed my branch and accidentally deleted my previous pull request.
Proposed solution for: #33 and #32 (Not all metrics added yet) 

Tested towards kea version 2.4

Changelog

- Moved shared resources to BaseExporter class
- Created a unified parse_metrics function that both modes use
- Updated socket-exporter to use BaseExporter-class and parse_metrics
- Implemented a HTTP exporter
- Uses logic to handle multiple services when pulling http statistics, instead of pulling one service at a time.
- Has the same issue where it is not known if the configuration have been changed so we check every time we reload the metrics.
- Updated CLI to support multiple modes, default mode == socket
- Added pool metrics
Example pool-metrics:
If pool == "" it is global metrics for the entire subnet.
```
kea_dhcp4_addresses_assigned_total{pool="",subnet="10.10.111.0/24",subnet_id="476"} 7.0
kea_dhcp4_addresses_assigned_total{pool="10.10.111.200-10.10.111.254",subnet="10.10.111.0/24",subnet_id="476"} 7.0
```