### PR TITLE
feat: add mTLS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Features
 --------
 
 - DHCP4 & DHCP6 Metrics (tested against Kea 1.6.0)
-- Configuration and statistics via control socket
+- Configuration and statistics via control socket or http api
 
 Currently not working:
 
@@ -50,7 +50,6 @@ Known Limitations
 
 The following features are not supported yet, help is welcome.
 
-- HTTP REST API (as a means to query a Kea instance)
 - Shared Networks
 - Custom Subnet Identifiers
 
@@ -62,11 +61,17 @@ Usage
     Usage: kea-exporter [OPTIONS] SOCKETS...
 
     Options:
-      --address TEXT      Specify the address to bind against.
-      --port INTEGER      Specify the port on which to listen.
-      --interval INTEGER  Specify the metrics update interval in seconds.
-      --version           Show the version and exit.
-      --help              Show this message and exit.
+    -m, --mode [socket|http]  Select mode.
+    -a, --address TEXT        Specify the address to bind against.
+    -p, --port INTEGER        Specify the port on which to listen.
+    -i, --interval INTEGER    Specify the metrics update interval in seconds.
+    -t, --target TEXT         Target address and port of Kea server, e.g.
+                               http://kea.example.com:8080.
+    --client-cert TEXT        Client certificate file path used in HTTP mode
+                               with mTLS
+    --client-key TEXT         Client key file path used in HTTP mode with mTLS
+    --version                 Show the version and exit.
+    --help                    Show this message and exit.
 
 
 
@@ -78,6 +83,11 @@ statistics. Consult the documentation on how to set up the control socket:
 
 - https://kea.readthedocs.io/en/latest/arm/dhcp4-srv.html#management-api-for-the-dhcpv4-server
 - https://kea.readthedocs.io/en/latest/arm/dhcp6-srv.html#management-api-for-the-dhcpv6-server
+
+HTTPS
+///////////
+If you need to validate a self-signed certificate on a Kea instance, you can set `REQUESTS_CA_BUNDLE`
+environment variable to a bundle CA path.
 
 Permissions
 ///////////

--- a/kea_exporter/cli.py
+++ b/kea_exporter/cli.py
@@ -45,6 +45,20 @@ from . import __PROJECT__, __VERSION__
     type=str,
     help="Target address and port of Kea server, e.g. http://kea.example.com:8080.",
 )
+@click.option(
+    "--client-cert",
+    envvar="CLIENT_CERT",
+    type=str,
+    help="Client certificate file path used in HTTP mode with mTLS",
+    required=False
+)
+@click.option(
+    "--client-key",
+    envvar="CLIENT_KEY",
+    type=str,
+    help="Client key file path used in HTTP mode with mTLS",
+    required=False
+)
 @click.argument("sockets", envvar="SOCKETS", nargs=-1, required=False)
 @click.version_option(prog_name=__PROJECT__, version=__VERSION__)
 def cli(mode, port, address, interval, **kwargs):

--- a/kea_exporter/cli.py
+++ b/kea_exporter/cli.py
@@ -50,14 +50,14 @@ from . import __PROJECT__, __VERSION__
     envvar="CLIENT_CERT",
     type=str,
     help="Client certificate file path used in HTTP mode with mTLS",
-    required=False
+    required=False,
 )
 @click.option(
     "--client-key",
     envvar="CLIENT_KEY",
     type=str,
     help="Client key file path used in HTTP mode with mTLS",
-    required=False
+    required=False,
 )
 @click.argument("sockets", envvar="SOCKETS", nargs=-1, required=False)
 @click.version_option(prog_name=__PROJECT__, version=__VERSION__)

--- a/kea_exporter/kea_http_exporter.py
+++ b/kea_exporter/kea_http_exporter.py
@@ -9,7 +9,10 @@ class KeaHTTPExporter(BaseExporter):
 
         self._target = target
         if client_cert and client_key:
-            self._cert = (client_cert, client_key,)
+            self._cert = (
+                client_cert,
+                client_key,
+            )
         else:
             self._cert = None
 

--- a/kea_exporter/kea_http_exporter.py
+++ b/kea_exporter/kea_http_exporter.py
@@ -4,10 +4,14 @@ from .base_exporter import BaseExporter
 
 
 class KeaHTTPExporter(BaseExporter):
-    def __init__(self, target, **kwargs):
+    def __init__(self, target, client_cert, client_key, **kwargs):
         super().__init__()
 
         self._target = target
+        if client_cert and client_key:
+            self._cert = (client_cert, client_key,)
+        else:
+            self._cert = None
 
         self.modules = []
         self.subnets = {}
@@ -19,6 +23,7 @@ class KeaHTTPExporter(BaseExporter):
     def load_modules(self):
         r = requests.post(
             self._target,
+            cert=self._cert,
             json={"command": "config-get"},
             headers={"Content-Type": "application/json"},
         )
@@ -30,6 +35,7 @@ class KeaHTTPExporter(BaseExporter):
     def load_subnets(self):
         r = requests.post(
             self._target,
+            cert=self._cert,
             json={"command": "config-get", "service": self.modules},
             headers={"Content-Type": "application/json"},
         )
@@ -46,6 +52,7 @@ class KeaHTTPExporter(BaseExporter):
         # Note for future testing: pipe curl output to jq for an easier read
         r = requests.post(
             self._target,
+            cert=self._cert,
             json={
                 "command": "statistic-get-all",
                 "arguments": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ requires-python = ">=3.7,<4.0"
 dependencies = [
     "click>=6.7",
     "prometheus-client>=0.1.1",
+    "requests~=2.31.0"
 ]
 readme = "README.rst"
 keywords = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ authors = [
 license = { text = "MIT" }
 requires-python = ">=3.7,<4.0"
 dependencies = [
-    "click>=6.7",
-    "prometheus-client>=0.1.1",
-    "requests~=2.31.0"
+    "click>=8.1.7,<9.0",
+    "prometheus-client>=0.1.1,<1.0",
+    "requests>=2.31.0,<3.0"
 ]
 readme = "README.rst"
 keywords = [


### PR DESCRIPTION
This PR adds the possibility to connect to a control agent with mTLS enabled (`cert-required`). I've also added a missing dependency.
I haven't included the option to pass a custom certificate authority since you can use the `REQUESTS_CA_BUNDLE` environment variable for that purpose. However, I can add it if you think it's not sufficient.

PS: I've pinned the requests dependency using `~=` to prevent installation issues in case of a major release. What are your thoughts on using this approach for all dependencies ?