### PR TITLE
Handle v6-ia/pd-na-lease-reuses metrics

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ A docker image is available and can be configured with environment variables see
 Features
 --------
 
-- DHCP4 & DHCP6 Metrics (tested against Kea 1.6.0)
+- DHCP4 & DHCP6 Metrics (tested against Kea 2.4.1)
 - Configuration and statistics via control socket or http api
 
 Currently not working:

--- a/kea_exporter/base_exporter.py
+++ b/kea_exporter/base_exporter.py
@@ -281,6 +281,9 @@ class BaseExporter:
                 "Size of non-temporary address pool",
                 ["subnet", "subnet_id", "pool"],
             ),
+            "na_reuses_total": Gauge(
+                f"{self.prefix_dhcp6}_na_reuses_total", "Number of IA_NA lease reuses", ["subnet", "subnet_id", "pool"]
+            ),
             # IA_PD
             "pd_assigned_total": Gauge(
                 f"{self.prefix_dhcp6}_pd_assigned_total",
@@ -291,6 +294,9 @@ class BaseExporter:
                 f"{self.prefix_dhcp6}_pd_total",
                 "Size of prefix delegation pool",
                 ["subnet", "subnet_id"],
+            ),
+            "pd_reuses_total": Gauge(
+                f"{self.prefix_dhcp6}_pd_reuses_total", "Number of IA_PD lease reuses", ["subnet", "subnet_id", "pool"]
             ),
         }
 
@@ -410,6 +416,8 @@ class BaseExporter:
             "v6-reservation-conflicts": {
                 "metric": "reservation_conflicts_total",
             },
+            "v6-ia-na-lease-reuses": {"metric": "na_reuses_total"},
+            "v6-ia-pd-lease-reuses": {"metric": "pd_reuses_total"},
         }
 
         # Ignore list for Global level metrics
@@ -428,6 +436,8 @@ class BaseExporter:
             "v6-allocation-fail-shared-network",
             "v6-allocation-fail-no-pools",
             "v6-allocation-fail-classes",
+            "v6-ia-na-lease-reuses",
+            "v6-ia-pd-lease-reuses",
             "pkt6-sent",
             "pkt6-received",
         ]


### PR DESCRIPTION
We're ignoring the global accumulated metric in favor of the per subnet metrics, that can be aggregated in Prometheus.

Closes: #32