### PR TITLE
Unify CLI target specification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,9 @@ The following features are not supported yet, help is welcome.
 Usage
 -----
 
+Pass one or multiple Unix Domain Socket path or HTTP Control-Agent URLs
+to the `kea-exporter` executable. All other options are optional.
+
 ::
 
 	Usage: python -m kea_exporter [OPTIONS] TARGETS...

--- a/README.rst
+++ b/README.rst
@@ -67,31 +67,26 @@ Usage
 
 ::
 
-    Usage: kea-exporter [OPTIONS] [SOCKETS]...
+	Usage: python -m kea_exporter [OPTIONS] TARGETS...
 
-    Options:
-    -m, --mode [socket|http]  Select mode.
-    -a, --address TEXT        Specify the address to bind against.
-    -p, --port INTEGER        Specify the port on which to listen.
-    -i, --interval INTEGER    Minimal interval between two queries to Kea in seconds.
-    -t, --target TEXT         Target address and port of Kea server, e.g.
-                               http://kea.example.com:8080.
-    --client-cert TEXT        Client certificate file path used in HTTP mode
-                               with mTLS
-    --client-key TEXT         Client key file path used in HTTP mode with mTLS
-    --version                 Show the version and exit.
-    --help                    Show this message and exit.
-
+	Options:
+	  -a, --address TEXT      Address that the exporter binds to.
+	  -p, --port INTEGER      Port that the exporter binds to.
+	  -i, --interval INTEGER  Minimal interval between two queries to Kea in
+	                          seconds.
+	  --client-cert PATH      Path to client certificate used to in HTTP requests
+	  --client-key PATH       Path to client key used in HTTP requests
+	  --version               Show the version and exit.
+	  --help                  Show this message and exit.
 
 You can also configure the exporter using environment variables:
 
 ::
 
-   export MODE="http"
    export ADDRESS="0.0.0.0"
    export PORT="9547"
    export INTERVAL="7.5"
-   export TARGET="http://kea"
+   export TARGETS="http://router.example.com:8000"
    export CLIENT_CERT="/etc/kea-exporter/client.crt"
    export CLIENT_KEY="/etc/kea-exporter/client.key"
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
             src = ./.;
             hooks = {
               isort.enable = true;
-              ruff.enable = false;
+              ruff.enable = true;
               ruff-format = {
                 enable = true;
                 entry = "${pkgs.ruff}/bin/ruff format";

--- a/kea_exporter/__init__.py
+++ b/kea_exporter/__init__.py
@@ -1,2 +1,9 @@
+from enum import Enum
+
 __project__ = "kea-exporter"
 __version__ = "0.6.2"
+
+
+class DHCPVersion(Enum):
+    DHCP4 = 1
+    DHCP6 = 2

--- a/kea_exporter/cli.py
+++ b/kea_exporter/cli.py
@@ -1,9 +1,11 @@
+import sys
 import time
 
 import click
 from prometheus_client import REGISTRY, make_wsgi_app, start_http_server
 
-from . import __project__, __version__
+from kea_exporter import __project__, __version__
+from kea_exporter.exporter import Exporter
 
 
 class Timer:
@@ -19,14 +21,6 @@ class Timer:
 
 
 @click.command()
-@click.option(
-    "-m",
-    "--mode",
-    envvar="MODE",
-    default="socket",
-    help="Select mode.",
-    type=click.Choice(["socket", "http"], case_sensitive=True),
-)
 @click.option(
     "-a",
     "--address",
@@ -51,13 +45,6 @@ class Timer:
     help="Minimal interval between two queries to Kea in seconds.",
 )
 @click.option(
-    "-t",
-    "--target",
-    envvar="TARGET",
-    type=str,
-    help="Target address and port of Kea server, e.g. http://kea.example.com:8080.",
-)
-@click.option(
     "--client-cert",
     envvar="CLIENT_CERT",
     type=str,
@@ -71,16 +58,13 @@ class Timer:
     help="Client key file path used in HTTP mode with mTLS",
     required=False,
 )
-@click.argument("sockets", envvar="SOCKETS", nargs=-1, required=False)
+@click.argument("targets", envvar="TARGETS", nargs=-1, required=True)
 @click.version_option(prog_name=__project__, version=__version__)
-def cli(mode, port, address, interval, **kwargs):
-    if mode == "socket":
-        from .kea_socket_exporter import KeaSocketExporter as KeaExporter
-    elif mode == "http":
-        from .kea_http_exporter import KeaHTTPExporter as KeaExporter
+def cli(port, address, interval, **kwargs):
+    exporter = Exporter(**kwargs)
 
-    exporter = KeaExporter(**kwargs)
-    exporter.update()
+    if not exporter.targets:
+        sys.exit(1)
 
     httpd, _ = start_http_server(port, address)
 

--- a/kea_exporter/cli.py
+++ b/kea_exporter/cli.py
@@ -25,8 +25,9 @@ class Timer:
     "-a",
     "--address",
     envvar="ADDRESS",
+    type=str,
     default="0.0.0.0",
-    help="Specify the address to bind against.",
+    help="Address that the exporter binds to.",
 )
 @click.option(
     "-p",
@@ -34,7 +35,7 @@ class Timer:
     envvar="PORT",
     type=int,
     default=9547,
-    help="Specify the port on which to listen.",
+    help="Port that the exporter binds to.",
 )
 @click.option(
     "-i",
@@ -47,15 +48,15 @@ class Timer:
 @click.option(
     "--client-cert",
     envvar="CLIENT_CERT",
-    type=str,
-    help="Client certificate file path used in HTTP mode with mTLS",
+    type=click.Path(exists=True),
+    help="Path to client certificate used to in HTTP requests",
     required=False,
 )
 @click.option(
     "--client-key",
     envvar="CLIENT_KEY",
-    type=str,
-    help="Client key file path used in HTTP mode with mTLS",
+    type=click.Path(exists=True),
+    help="Path to client key used in HTTP requests",
     required=False,
 )
 @click.argument("targets", envvar="TARGETS", nargs=-1, required=True)

--- a/kea_exporter/http.py
+++ b/kea_exporter/http.py
@@ -1,9 +1,9 @@
 import requests
 
-from .base_exporter import BaseExporter
+from kea_exporter import DHCPVersion
 
 
-class KeaHTTPExporter(BaseExporter):
+class KeaHTTPClient:
     def __init__(self, target, client_cert, client_key, **kwargs):
         super().__init__()
 
@@ -49,7 +49,7 @@ class KeaHTTPExporter(BaseExporter):
             for subnet in module.get("arguments", {}).get("Dhcp6", {}).get("subnet6", {}):
                 self.subnets6.update({subnet["id"]: subnet})
 
-    def update(self):
+    def stats(self):
         # Reload subnets on update in case of configurational update
         self.load_subnets()
         # Note for future testing: pipe curl output to jq for an easier read
@@ -67,14 +67,14 @@ class KeaHTTPExporter(BaseExporter):
 
         for index, module in enumerate(self.modules):
             if module == "dhcp4":
-                dhcp_version = self.DHCPVersion.DHCP4
+                dhcp_version = DHCPVersion.DHCP4
                 subnets = self.subnets
             elif module == "dhcp6":
-                dhcp_version = self.DHCPVersion.DHCP6
+                dhcp_version = DHCPVersion.DHCP6
                 subnets = self.subnets6
             else:
                 continue
 
             arguments = response[index].get("arguments", {})
 
-            self.parse_metrics(dhcp_version, arguments, subnets)
+            yield dhcp_version, arguments, subnets


### PR DESCRIPTION
Both HTTP URLs and UNIX Domain Socket paths can be passed as arguments
with this change.

@M0NsTeRRR `TARGET` becomes `TARGETS` with this change.