### PR TITLE
Include target name as label

### DIFF
--- a/kea_exporter/exporter.py
+++ b/kea_exporter/exporter.py
@@ -72,7 +72,7 @@ class Exporter:
             "received_packets": Gauge(
                 f"{self.prefix_dhcp4}_packets_received_total",
                 "Packets received",
-                ["operation"],
+                ["operation", "server"],
             ),
             # per Subnet or Subnet pool
             "addresses_allocation_fail": Gauge(
@@ -82,42 +82,43 @@ class Exporter:
                     "subnet",
                     "subnet_id",
                     "context",
+                    "server",
                 ],
             ),
             "addresses_assigned_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_assigned_total",
                 "Assigned addresses",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "pool", "server"],
             ),
             "addresses_declined_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_declined_total",
                 "Declined counts",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "pool", "server"],
             ),
             "addresses_declined_reclaimed_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_declined_reclaimed_total",
                 "Declined addresses that were reclaimed",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "pool", "server"],
             ),
             "addresses_reclaimed_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_reclaimed_total",
                 "Expired addresses that were reclaimed",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "pool", "server"],
             ),
             "addresses_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_total",
                 "Size of subnet address pool",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "pool", "server"],
             ),
             "reservation_conflicts_total": Gauge(
                 f"{self.prefix_dhcp4}_reservation_conflicts_total",
                 "Reservation conflict count",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "server"],
             ),
             "leases_reused_total": Gauge(
                 f"{self.prefix_dhcp4}_leases_reused_total",
                 "Number of times an IPv4 lease has been renewed in memory",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "server"],
             ),
         }
 
@@ -246,22 +247,22 @@ class Exporter:
     def setup_dhcp6_metrics(self):
         self.metrics_dhcp6 = {
             # Packets sent/received
-            "sent_packets": Gauge(f"{self.prefix_dhcp6}_packets_sent_total", "Packets sent", ["operation"]),
+            "sent_packets": Gauge(f"{self.prefix_dhcp6}_packets_sent_total", "Packets sent", ["operation", "server"]),
             "received_packets": Gauge(
                 f"{self.prefix_dhcp6}_packets_received_total",
                 "Packets received",
-                ["operation"],
+                ["operation", "server"],
             ),
             # DHCPv4-over-DHCPv6
             "sent_dhcp4_packets": Gauge(
                 f"{self.prefix_dhcp6}_packets_sent_dhcp4_total",
                 "DHCPv4-over-DHCPv6 Packets received",
-                ["operation"],
+                ["operation", "server"],
             ),
             "received_dhcp4_packets": Gauge(
                 f"{self.prefix_dhcp6}_packets_received_dhcp4_total",
                 "DHCPv4-over-DHCPv6 Packets received",
-                ["operation"],
+                ["operation", "server"],
             ),
             # per Subnet or pool
             "addresses_allocation_fail": Gauge(
@@ -271,55 +272,56 @@ class Exporter:
                     "subnet",
                     "subnet_id",
                     "context",
+                    "server",
                 ],
             ),
             "addresses_declined_total": Gauge(
                 f"{self.prefix_dhcp6}_addresses_declined_total",
                 "Declined addresses",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "pool", "server"],
             ),
             "addresses_declined_reclaimed_total": Gauge(
                 f"{self.prefix_dhcp6}_addresses_declined_reclaimed_total",
                 "Declined addresses that were reclaimed",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "pool", "server"],
             ),
             "addresses_reclaimed_total": Gauge(
                 f"{self.prefix_dhcp6}_addresses_reclaimed_total",
                 "Expired addresses that were reclaimed",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "pool", "server"],
             ),
             "reservation_conflicts_total": Gauge(
                 f"{self.prefix_dhcp6}_reservation_conflicts_total",
                 "Reservation conflict count",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "server"],
             ),
             # IA_NA
             "na_assigned_total": Gauge(
                 f"{self.prefix_dhcp6}_na_assigned_total",
                 "Assigned non-temporary addresses (IA_NA)",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "pool", "server"],
             ),
             "na_total": Gauge(
                 f"{self.prefix_dhcp6}_na_total",
                 "Size of non-temporary address pool",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "pool", "server"],
             ),
             "na_reuses_total": Gauge(
-                f"{self.prefix_dhcp6}_na_reuses_total", "Number of IA_NA lease reuses", ["subnet", "subnet_id", "pool"]
+                f"{self.prefix_dhcp6}_na_reuses_total", "Number of IA_NA lease reuses", ["subnet", "subnet_id", "pool", "server"]
             ),
             # IA_PD
             "pd_assigned_total": Gauge(
                 f"{self.prefix_dhcp6}_pd_assigned_total",
                 "Assigned prefix delegations (IA_PD)",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "server"],
             ),
             "pd_total": Gauge(
                 f"{self.prefix_dhcp6}_pd_total",
                 "Size of prefix delegation pool",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "server"],
             ),
             "pd_reuses_total": Gauge(
-                f"{self.prefix_dhcp6}_pd_reuses_total", "Number of IA_PD lease reuses", ["subnet", "subnet_id", "pool"]
+                f"{self.prefix_dhcp6}_pd_reuses_total", "Number of IA_PD lease reuses", ["subnet", "subnet_id", "pool", "server"]
             ),
         }
 
@@ -472,7 +474,7 @@ class Exporter:
             "v6-allocation-fail",
         ]
 
-    def parse_metrics(self, dhcp_version, arguments, subnets):
+    def parse_metrics(self, target_name, dhcp_version, arguments, subnets):
         for key, data in arguments.items():
             if dhcp_version is DHCPVersion.DHCP4:
                 if key in self.metrics_dhcp4_global_ignore:
@@ -567,6 +569,7 @@ class Exporter:
 
             # merge static and dynamic labels
             labels.update(metric_info.get("labels", {}))
+            labels.update("server": target_name)
 
             # Filter labels that are not configured for the metric
             labels = {key: val for key, val in labels.items() if key in metric._labelnames}

--- a/kea_exporter/exporter.py
+++ b/kea_exporter/exporter.py
@@ -522,7 +522,7 @@ class Exporter:
                     continue
 
                 labels["subnet"] = subnet_data.get("subnet")
-                labels["subnet_name"] = subnet_data.get("user-context", {}).get("name")
+                labels["subnet_name"] = subnet_data.get("user-context", {}).get("name", "")
                 labels["subnet_id"] = subnet_id
 
                 # Check if subnet matches the pool_index

--- a/kea_exporter/exporter.py
+++ b/kea_exporter/exporter.py
@@ -81,43 +81,44 @@ class Exporter:
                 [
                     "subnet",
                     "subnet_id",
+                    "subnet_name",
                     "context",
                 ],
             ),
             "addresses_assigned_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_assigned_total",
                 "Assigned addresses",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "addresses_declined_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_declined_total",
                 "Declined counts",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "addresses_declined_reclaimed_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_declined_reclaimed_total",
                 "Declined addresses that were reclaimed",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "addresses_reclaimed_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_reclaimed_total",
                 "Expired addresses that were reclaimed",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "addresses_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_total",
                 "Size of subnet address pool",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "reservation_conflicts_total": Gauge(
                 f"{self.prefix_dhcp4}_reservation_conflicts_total",
                 "Reservation conflict count",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "subnet_name"],
             ),
             "leases_reused_total": Gauge(
                 f"{self.prefix_dhcp4}_leases_reused_total",
                 "Number of times an IPv4 lease has been renewed in memory",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "subnet_name"],
             ),
         }
 
@@ -270,56 +271,57 @@ class Exporter:
                 [
                     "subnet",
                     "subnet_id",
+                    "subnet_name",
                     "context",
                 ],
             ),
             "addresses_declined_total": Gauge(
                 f"{self.prefix_dhcp6}_addresses_declined_total",
                 "Declined addresses",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "addresses_declined_reclaimed_total": Gauge(
                 f"{self.prefix_dhcp6}_addresses_declined_reclaimed_total",
                 "Declined addresses that were reclaimed",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "addresses_reclaimed_total": Gauge(
                 f"{self.prefix_dhcp6}_addresses_reclaimed_total",
                 "Expired addresses that were reclaimed",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "reservation_conflicts_total": Gauge(
                 f"{self.prefix_dhcp6}_reservation_conflicts_total",
                 "Reservation conflict count",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "subnet_name"],
             ),
             # IA_NA
             "na_assigned_total": Gauge(
                 f"{self.prefix_dhcp6}_na_assigned_total",
                 "Assigned non-temporary addresses (IA_NA)",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "na_total": Gauge(
                 f"{self.prefix_dhcp6}_na_total",
                 "Size of non-temporary address pool",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "na_reuses_total": Gauge(
-                f"{self.prefix_dhcp6}_na_reuses_total", "Number of IA_NA lease reuses", ["subnet", "subnet_id", "pool"]
+                f"{self.prefix_dhcp6}_na_reuses_total", "Number of IA_NA lease reuses", ["subnet", "subnet_id", "subnet_name", "pool"]
             ),
             # IA_PD
             "pd_assigned_total": Gauge(
                 f"{self.prefix_dhcp6}_pd_assigned_total",
                 "Assigned prefix delegations (IA_PD)",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "subnet_name"],
             ),
             "pd_total": Gauge(
                 f"{self.prefix_dhcp6}_pd_total",
                 "Size of prefix delegation pool",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "subnet_name"],
             ),
             "pd_reuses_total": Gauge(
-                f"{self.prefix_dhcp6}_pd_reuses_total", "Number of IA_PD lease reuses", ["subnet", "subnet_id", "pool"]
+                f"{self.prefix_dhcp6}_pd_reuses_total", "Number of IA_PD lease reuses", ["subnet", "subnet_id", "subnet_name", "pool"]
             ),
         }
 
@@ -520,6 +522,7 @@ class Exporter:
                     continue
 
                 labels["subnet"] = subnet_data.get("subnet")
+                labels["subnet_name"] = subnet_data.get("user-context", {}).get("name")
                 labels["subnet_id"] = subnet_id
 
                 # Check if subnet matches the pool_index

--- a/kea_exporter/exporter.py
+++ b/kea_exporter/exporter.py
@@ -569,7 +569,7 @@ class Exporter:
 
             # merge static and dynamic labels
             labels.update(metric_info.get("labels", {}))
-            labels.update("server": target_name)
+            labels.update({"server": target_name})
 
             # Filter labels that are not configured for the metric
             labels = {key: val for key, val in labels.items() if key in metric._labelnames}

--- a/kea_exporter/http.py
+++ b/kea_exporter/http.py
@@ -77,4 +77,4 @@ class KeaHTTPClient:
 
             arguments = response[index].get("arguments", {})
 
-            yield dhcp_version, arguments, subnets
+            yield self._target, dhcp_version, arguments, subnets

--- a/kea_exporter/uds.py
+++ b/kea_exporter/uds.py
@@ -43,7 +43,7 @@ class KeaSocketClient:
 
         arguments = self.query("statistic-get-all").get("arguments", {})
 
-        yield self.dhcp_version, arguments, self.subnets
+        yield self.sock_path, self.dhcp_version, arguments, self.subnets
 
     def reload(self):
         self.config = self.query("config-get")["arguments"]


### PR DESCRIPTION
This PR adds the name of the target (either remote host URL or local socket path) to the exported metric. Useful for installations supporting multiple targets.