### PR TITLE
Include subnet name

### DIFF
--- a/kea_exporter/exporter.py
+++ b/kea_exporter/exporter.py
@@ -522,7 +522,7 @@ class Exporter:
                     continue
 
                 labels["subnet"] = subnet_data.get("subnet")
-                labels["subnet_name"] = subnet_data.get("user-context", {}).get("name")
+                labels["subnet_name"] = subnet_data.get("user-context", {}).get("name", "")
                 labels["subnet_id"] = subnet_id
 
                 # Check if subnet matches the pool_index

--- a/kea_exporter/exporter.py
+++ b/kea_exporter/exporter.py
@@ -81,43 +81,44 @@ class Exporter:
                 [
                     "subnet",
                     "subnet_id",
+                    "subnet_name",
                     "context",
                 ],
             ),
             "addresses_assigned_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_assigned_total",
                 "Assigned addresses",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "addresses_declined_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_declined_total",
                 "Declined counts",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "addresses_declined_reclaimed_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_declined_reclaimed_total",
                 "Declined addresses that were reclaimed",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "addresses_reclaimed_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_reclaimed_total",
                 "Expired addresses that were reclaimed",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "addresses_total": Gauge(
                 f"{self.prefix_dhcp4}_addresses_total",
                 "Size of subnet address pool",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "reservation_conflicts_total": Gauge(
                 f"{self.prefix_dhcp4}_reservation_conflicts_total",
                 "Reservation conflict count",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "subnet_name"],
             ),
             "leases_reused_total": Gauge(
                 f"{self.prefix_dhcp4}_leases_reused_total",
                 "Number of times an IPv4 lease has been renewed in memory",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "subnet_name"],
             ),
         }
 
@@ -270,56 +271,57 @@ class Exporter:
                 [
                     "subnet",
                     "subnet_id",
+                    "subnet_name",
                     "context",
                 ],
             ),
             "addresses_declined_total": Gauge(
                 f"{self.prefix_dhcp6}_addresses_declined_total",
                 "Declined addresses",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "addresses_declined_reclaimed_total": Gauge(
                 f"{self.prefix_dhcp6}_addresses_declined_reclaimed_total",
                 "Declined addresses that were reclaimed",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "addresses_reclaimed_total": Gauge(
                 f"{self.prefix_dhcp6}_addresses_reclaimed_total",
                 "Expired addresses that were reclaimed",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "reservation_conflicts_total": Gauge(
                 f"{self.prefix_dhcp6}_reservation_conflicts_total",
                 "Reservation conflict count",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "subnet_name"],
             ),
             # IA_NA
             "na_assigned_total": Gauge(
                 f"{self.prefix_dhcp6}_na_assigned_total",
                 "Assigned non-temporary addresses (IA_NA)",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "na_total": Gauge(
                 f"{self.prefix_dhcp6}_na_total",
                 "Size of non-temporary address pool",
-                ["subnet", "subnet_id", "pool"],
+                ["subnet", "subnet_id", "subnet_name", "pool"],
             ),
             "na_reuses_total": Gauge(
-                f"{self.prefix_dhcp6}_na_reuses_total", "Number of IA_NA lease reuses", ["subnet", "subnet_id", "pool"]
+                f"{self.prefix_dhcp6}_na_reuses_total", "Number of IA_NA lease reuses", ["subnet", "subnet_id", "subnet_name", "pool"]
             ),
             # IA_PD
             "pd_assigned_total": Gauge(
                 f"{self.prefix_dhcp6}_pd_assigned_total",
                 "Assigned prefix delegations (IA_PD)",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "subnet_name"],
             ),
             "pd_total": Gauge(
                 f"{self.prefix_dhcp6}_pd_total",
                 "Size of prefix delegation pool",
-                ["subnet", "subnet_id"],
+                ["subnet", "subnet_id", "subnet_name"],
             ),
             "pd_reuses_total": Gauge(
-                f"{self.prefix_dhcp6}_pd_reuses_total", "Number of IA_PD lease reuses", ["subnet", "subnet_id", "pool"]
+                f"{self.prefix_dhcp6}_pd_reuses_total", "Number of IA_PD lease reuses", ["subnet", "subnet_id", "subnet_name", "pool"]
             ),
         }
 
@@ -520,6 +522,7 @@ class Exporter:
                     continue
 
                 labels["subnet"] = subnet_data.get("subnet")
+                labels["subnet_name"] = subnet_data.get("user-context", {}).get("name")
                 labels["subnet_id"] = subnet_id
 
                 # Check if subnet matches the pool_index


### PR DESCRIPTION
This PR will pull an optional subnet name from the user-context of a subnet configuration and include it as a label:

```
"subnet4": [{
    "subnet": "192.168.0.0/24"
    "user-context": {
        "name": "My Test Subnet"
    },
    "pools": [ ... ]
}]
```